### PR TITLE
Better constrained the customAlert's view

### DIFF
--- a/DJHelper/DJHelper/Helpers/CustomAlert.swift
+++ b/DJHelper/DJHelper/Helpers/CustomAlert.swift
@@ -52,15 +52,6 @@ class CustomAlert {
 
         alertView.addSubview(titleLabel)
 
-        // CONFIGURE MESSAGE LABEL
-        let messageLabel = UILabel(frame: CGRect(x: 0, y: 80, width: alertView.frame.size.width, height: 170))
-
-        messageLabel.numberOfLines = 0
-        messageLabel.text = message
-        messageLabel.textAlignment = .left
-
-        alertView.addSubview(messageLabel)
-
         //CONFIGURE BUTTON
         let button = UIButton(frame: CGRect(x: 0, y: alertView.frame.size.height - 50, width: alertView.frame.size.width, height: 50))
 
@@ -81,6 +72,25 @@ class CustomAlert {
                 })
             }
         })
+
+        // CONFIGURE MESSAGE LABEL
+        let messageLabel = UILabel()
+
+        messageLabel.numberOfLines = 0
+        messageLabel.text = message
+        messageLabel.font = UIFont(name: "Palatino", size: 18)
+        messageLabel.textAlignment = .left
+        messageLabel.lineBreakMode = .byWordWrapping
+
+        alertView.addSubview(messageLabel)
+
+        messageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate(
+            [messageLabel.leadingAnchor.constraint(equalTo: alertView.leadingAnchor),
+             messageLabel.trailingAnchor.constraint(equalTo: alertView.trailingAnchor),
+             messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: -60),
+             messageLabel.bottomAnchor.constraint(equalTo: button.topAnchor, constant: 10)]
+        )
     }
 
     @objc func dismissAlert() {


### PR DESCRIPTION
# Description
Updated/cleaned up the CustomAlert class - body of message should look cleaner and added constraints based on the alert view itself. 

## Change Status
- [ X] Complete, but not tested (may need new tests)

# Checklist

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ X] There are no merge conflicts
